### PR TITLE
Add benchmarks to gorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ Solution (Kahn): [1 {3.141592653589793} 3 5 4]
 Solution (DFS-based): [1 {3.141592653589793} 3 5 4]
 ```
 
+## Benchmarking
+To benchmark the different algorithms, run the command below.
+```sh
+go test ./... -bench=. -run=xxx
+```
+You can add the flag `-benchmem` if you want to see the memory allocations.
+```sh
+go test ./... -bench=. -run=xxx -benchmem
+```
+
+
 ## Notes:
 
 * Maps are one of the common ways to store graphs in Go. The `TopologicalSort` function input supports `map[interface{}][]interface{}` maps.
 
-* Sub-package `dagenerator` was developed and used for generating random DAGs for performance tests (`cmd/measurements` should be rewritten as benchmarks).
+* Sub-package `dagenerator` was developed and used for generating random DAGs for performance tests.
 
 * Implementation of Kahn's algorithm does pre-computation in the beginning of its work in order to calculate indegree of every vertex in the graph. This may be split into two separate algorithms/functions in the future:
     - one that doesn't take any additional input but the graph (current implementation)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Solution (DFS-based): [1 {3.141592653589793} 3 5 4]
 ```
 
 ## Benchmarking
-To benchmark the different algorithms, run the command below.
+
+To benchmark the different algorithms, run the command below:
+
 ```sh
 go test ./... -bench=. -run=xxx
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You can add the flag `-benchmem` if you want to see the memory allocations:
 go test ./... -bench=. -run=xxx -benchmem
 ```
 
-
 ## Notes:
 
 * Maps are one of the common ways to store graphs in Go. The `TopologicalSort` function input supports `map[interface{}][]interface{}` maps.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ To benchmark the different algorithms, run the command below:
 ```sh
 go test ./... -bench=. -run=xxx
 ```
-You can add the flag `-benchmem` if you want to see the memory allocations.
+
+You can add the flag `-benchmem` if you want to see the memory allocations:
+
 ```sh
 go test ./... -bench=. -run=xxx -benchmem
 ```

--- a/gorder_test.go
+++ b/gorder_test.go
@@ -56,18 +56,9 @@ func TestTopologicalSort(t *testing.T) {
 	}
 }
 
-func BenchmarkDFSBasedSort(b *testing.B) {
+func BenchmarkTopologicalSort(b *testing.B) {
 	digraph := dagenerator.Generate(10, 50, 30, 50, 30)
-	b.Run("ultrasuperfast", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, err := TopologicalSort(digraph, "ultrasuperfast")
-			if err == nil {
-				b.Fatal("TopologicalSort: should have returned an error")
-			}
-		}
-	})
-
-	b.Run("Kahn", func(b *testing.B) {
+	b.Run("kahn", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := TopologicalSort(digraph, "kahn")
 			if err != nil {

--- a/gorder_test.go
+++ b/gorder_test.go
@@ -1,6 +1,10 @@
 package gorder
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/amwolff/gorder/dagenerator"
+)
 
 func TestTopologicalSort(t *testing.T) {
 	digraph := map[interface{}][]interface{}{
@@ -50,4 +54,33 @@ func TestTopologicalSort(t *testing.T) {
 	if err == nil {
 		t.Fatal("DFS-based: should have returned an error")
 	}
+}
+
+func BenchmarkDFSBasedSort(b *testing.B) {
+	digraph := dagenerator.Generate(10, 50, 30, 50, 30)
+	b.Run("ultrasuperfast", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "ultrasuperfast")
+			if err == nil {
+				b.Fatal("TopologicalSort: should have returned an error")
+			}
+		}
+	})
+
+	b.Run("Kahn", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "kahn")
+			if err != nil {
+				b.Errorf("Kahn: %v", err)
+			}
+		}
+	})
+	b.Run("dfs based", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "dfsbased")
+			if err != nil {
+				b.Errorf("DFS-based: %v", err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Description
This MR adds benchmarks to this package using golang's benchmarking tool, making it easier to compare and contrast the differences in speed. This replaces the benchmarks in measurements.go as it provides a cleaner output.