### PR TITLE
Add go generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ Solution (Kahn): [1 {3.141592653589793} 3 5 4]
 Solution (DFS-based): [1 {3.141592653589793} 3 5 4]
 ```
 
+## Benchmarking
+To benchmark the different algorithms, run the command below.
+```sh
+go test ./... -bench=. -run=xxx
+```
+You can add the flag `-benchmem` if you want to see the memory allocations.
+```sh
+go test ./... -bench=. -run=xxx -benchmem
+```
+
+
 ## Notes:
 
 * Maps are one of the common ways to store graphs in Go. The `TopologicalSort` function input supports `map[interface{}][]interface{}` maps.
 
-* Sub-package `dagenerator` was developed and used for generating random DAGs for performance tests (`cmd/measurements` should be rewritten as benchmarks).
+* Sub-package `dagenerator` was developed and used for generating random DAGs for performance tests.
 
 * Implementation of Kahn's algorithm does pre-computation in the beginning of its work in order to calculate indegree of every vertex in the graph. This may be split into two separate algorithms/functions in the future:
     - one that doesn't take any additional input but the graph (current implementation)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/amwolff/gorder
 
-go 1.16
+go 1.20
 
 require github.com/davecgh/go-spew v1.1.1

--- a/gorder.go
+++ b/gorder.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-func TopologicalSort(digraph map[interface{}][]interface{}, algorithm string) (solution []interface{}, err error) {
+func TopologicalSort[T comparable, V []T](digraph map[T]V, algorithm string) (solution V, err error) {
 	kahnRgxp, err := regexp.Compile(`[Kk]ahn\z`)
 	if err != nil {
 		return nil, err
@@ -29,24 +29,24 @@ func TopologicalSort(digraph map[interface{}][]interface{}, algorithm string) (s
 	return solution, nil
 }
 
-func kahn(digraph map[interface{}][]interface{}) ([]interface{}, error) {
-	indegrees := make(map[interface{}]int)
-	for u := range digraph {
-		if digraph[u] != nil {
-			for _, v := range digraph[u] {
-				indegrees[v]++
-			}
+func kahn[T comparable, V []T](digraph map[T]V) (V, error) {
+	indegrees := make(map[T]int)
+
+	// loop through all diagraph and add increase indegrees of values
+	for _, iter := range digraph {
+		for _, v := range iter {
+			indegrees[v]++
 		}
 	}
 
-	var queue []interface{}
+	var queue V
 	for u := range digraph {
 		if _, ok := indegrees[u]; !ok {
 			queue = append(queue, u)
 		}
 	}
 
-	var order []interface{}
+	var order V
 	for len(queue) > 0 {
 		u := queue[len(queue)-1]
 		queue = queue[:(len(queue) - 1)]
@@ -67,16 +67,16 @@ func kahn(digraph map[interface{}][]interface{}) ([]interface{}, error) {
 	return order, nil
 }
 
-func dfsBased(digraph map[interface{}][]interface{}) ([]interface{}, error) {
+func dfsBased[T comparable, V []T](digraph map[T]V) (V, error) {
 	var (
 		acyclic       = true
-		order         []interface{}
-		permanentMark = make(map[interface{}]bool)
-		temporaryMark = make(map[interface{}]bool)
-		visit         func(interface{})
+		order         V
+		permanentMark = make(map[T]bool)
+		temporaryMark = make(map[T]bool)
+		visit         func(T)
 	)
 
-	visit = func(u interface{}) {
+	visit = func(u T) {
 		if temporaryMark[u] {
 			acyclic = false
 		} else if !(temporaryMark[u] || permanentMark[u]) {
@@ -89,7 +89,7 @@ func dfsBased(digraph map[interface{}][]interface{}) ([]interface{}, error) {
 			}
 			delete(temporaryMark, u)
 			permanentMark[u] = true
-			order = append([]interface{}{u}, order...)
+			order = append(V{u}, order...)
 		}
 	}
 

--- a/gorder_test.go
+++ b/gorder_test.go
@@ -56,18 +56,9 @@ func TestTopologicalSort(t *testing.T) {
 	}
 }
 
-func BenchmarkDFSBasedSort(b *testing.B) {
+func BenchmarkTopologicalSort(b *testing.B) {
 	digraph := dagenerator.Generate(10, 50, 30, 50, 30)
-	b.Run("ultrasuperfast", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, err := TopologicalSort(digraph, "ultrasuperfast")
-			if err == nil {
-				b.Fatal("TopologicalSort: should have returned an error")
-			}
-		}
-	})
-
-	b.Run("Kahn", func(b *testing.B) {
+	b.Run("kahn", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := TopologicalSort(digraph, "kahn")
 			if err != nil {

--- a/gorder_test.go
+++ b/gorder_test.go
@@ -1,6 +1,10 @@
 package gorder
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/amwolff/gorder/dagenerator"
+)
 
 func TestTopologicalSort(t *testing.T) {
 	digraph := map[interface{}][]interface{}{
@@ -50,4 +54,33 @@ func TestTopologicalSort(t *testing.T) {
 	if err == nil {
 		t.Fatal("DFS-based: should have returned an error")
 	}
+}
+
+func BenchmarkDFSBasedSort(b *testing.B) {
+	digraph := dagenerator.Generate(10, 50, 30, 50, 30)
+	b.Run("ultrasuperfast", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "ultrasuperfast")
+			if err == nil {
+				b.Fatal("TopologicalSort: should have returned an error")
+			}
+		}
+	})
+
+	b.Run("Kahn", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "kahn")
+			if err != nil {
+				b.Errorf("Kahn: %v", err)
+			}
+		}
+	})
+	b.Run("dfs based", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := TopologicalSort(digraph, "dfsbased")
+			if err != nil {
+				b.Errorf("DFS-based: %v", err)
+			}
+		}
+	})
 }

--- a/gorder_test.go
+++ b/gorder_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestTopologicalSort(t *testing.T) {
-	digraph := map[interface{}][]interface{}{
-		1: []interface{}{2, 4},
-		2: []interface{}{3, 5},
-		3: []interface{}{4, 5},
+	digraph := map[int][]int{
+		1: {2, 4},
+		2: {3, 5},
+		3: {4, 5},
 	}
 
 	want := []int{1, 2, 3, 5, 4}
@@ -40,11 +40,11 @@ func TestTopologicalSort(t *testing.T) {
 		}
 	}
 
-	graphWithCycles := map[interface{}][]interface{}{
-		1: []interface{}{2, 4},
-		2: []interface{}{3, 5},
-		3: []interface{}{4, 5},
-		4: []interface{}{2},
+	graphWithCycles := map[int][]int{
+		1: {2, 4},
+		2: {3, 5},
+		3: {4, 5},
+		4: {2},
 	}
 	_, err = TopologicalSort(graphWithCycles, "kahn")
 	if err == nil {


### PR DESCRIPTION
## Description
This MR adds go generics to the code to add a layer of type safety. Maps can now constrain their keys to receiving only comparable values avoiding errors